### PR TITLE
BUGFIX: Allow translation overrides

### DIFF
--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file original="" product-name="GesagtGetan.CookieDialogue" source-language="en" target-language="de" datatype="plaintext">
+    <file original="Main" product-name="GesagtGetan.CookieDialogue" source-language="en" target-language="de" datatype="plaintext">
         <body>
             <trans-unit id="cookiedialogue.text" xml:space="preserve">
                 <source><![CDATA[This website uses Cookies that are necessary for full use of the website. Detailed information about the use of Cookies on this website can be found in our <a href="{link}">data privacy policy</a>. There, the use of Cookies can also be set.]]></source>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file original="" product-name="GesagtGetan.CookieDialogue" source-language="en" datatype="plaintext">
+    <file original="Main" product-name="GesagtGetan.CookieDialogue" source-language="en" datatype="plaintext">
         <body>
             <trans-unit id="cookiedialogue.text" xml:space="preserve">
                 <source><![CDATA[This website uses Cookies that are necessary for full use of the website. Detailed information about the use of Cookies on this website can be found in our <a href="{link}">data privacy policy</a>. There, the use of Cookies can also be set.]]></source>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file original="" product-name="GesagtGetan.CookieDialogue" source-language="en" target-language="fr" datatype="plaintext">
+    <file original="Main" product-name="GesagtGetan.CookieDialogue" source-language="en" target-language="fr" datatype="plaintext">
         <body>
             <trans-unit id="cookiedialogue.text" xml:space="preserve">
                 <source><![CDATA[This website uses Cookies that are necessary for full use of the website. Detailed information about the use of Cookies on this website can be found in our <a href="{link}">data privacy policy</a>. There, the use of Cookies can also be set.]]></source>


### PR DESCRIPTION
Without `original` being set, translation overrides do not work as
documented in https://flowframework.readthedocs.io/en/stable/TheDefinitiveGuide/PartIII/Internationalization.html#xliff-file-overrides
